### PR TITLE
use default client config loading rules

### DIFF
--- a/cmd/deployment.go
+++ b/cmd/deployment.go
@@ -72,7 +72,7 @@ func printDeploymentView() {
 }
 
 func deploymentInfo() []DeploymentInfo {
-	clientset := util.GetClientset(kubeconfig)
+	clientset := util.GetClientset(kubeconfig, context)
 
 	depList, err := clientset.AppsV1beta2().Deployments(namespace).List(metav1.ListOptions{})
 	if err != nil {

--- a/cmd/nodes.go
+++ b/cmd/nodes.go
@@ -81,7 +81,7 @@ func NewPodStatus(pod v1.Pod) PodStatus {
 }
 
 func nodeMap() map[string]NodePodInfo {
-	clientset := util.GetClientset(kubeconfig)
+	clientset := util.GetClientset(kubeconfig, context)
 
 	podList, err := clientset.CoreV1().Pods(namespace).List(metav1.ListOptions{})
 	if err != nil {

--- a/cmd/root.go
+++ b/cmd/root.go
@@ -65,13 +65,4 @@ func initConfig() {
 		fmt.Println("Using config file:", viper.ConfigFileUsed())
 	}
 
-	if kubeconfig == "" {
-		if kenv := os.Getenv("KUBECONFIG"); kenv != "" {
-			kubeconfig = kenv
-		} else if h := os.Getenv("HOME"); h != "" {
-			kubeconfig = fmt.Sprintf("%v/.kube/config", h)
-		} else {
-			panic(fmt.Errorf("error setting default kubeconfig. $HOME not set"))
-		}
-	}
 }

--- a/cmd/service.go
+++ b/cmd/service.go
@@ -53,7 +53,7 @@ func showServiceView() {
 }
 
 func getServiceInfo() []ServiceInfo {
-	clientset := util.GetClientset(kubeconfig)
+	clientset := util.GetClientset(kubeconfig, context)
 
 	serviceList, err := clientset.CoreV1().Services(namespace).List(metav1.ListOptions{})
 	if err != nil {

--- a/util/k8s.go
+++ b/util/k8s.go
@@ -90,9 +90,13 @@ func K8sCommandArgs(args []string, namespace string, context string, labels stri
 	return args
 }
 
-func GetClientset(kubeconfig string) *kubernetes.Clientset {
-	// use the current context in kubeconfig
-	config, err := clientcmd.BuildConfigFromFlags("", kubeconfig)
+func GetClientset(kubeconfig, context string) *kubernetes.Clientset {
+
+	rules := clientcmd.NewDefaultClientConfigLoadingRules()
+	rules.ExplicitPath = kubeconfig
+	overrides := &clientcmd.ConfigOverrides{CurrentContext: context}
+
+	config, err := clientcmd.NewNonInteractiveDeferredLoadingClientConfig(rules, overrides).ClientConfig()
 	if err != nil {
 		panic(err.Error())
 	}


### PR DESCRIPTION
This PR changes the way the client config is loaded to more similar in how it works for `kubectl`.

In particular this allows to have multiple kubeconfig files referenced in the`KUBECONFIG` environment variable (separated by `:`) that are merged. Its also fixes specifying `--context` on the command line which didn't work correctly before.

